### PR TITLE
Fix parameter name when listing full docs

### DIFF
--- a/lib/resources/documents.js
+++ b/lib/resources/documents.js
@@ -16,13 +16,13 @@ util.inherits(Documents, Resource);
 // options.vault_id - vault uuid
 // options.page - which page (default 1)
 // options.per_page - items per page (default 100)
-// options.full_document - (default false)
+// options.full - (default false)
 // callback is options, this method retuns a q promise
 Documents.prototype.list = function(options, callback) {
 
   var query = querystring.stringify({
     page : options.page || 1,
-    full_document : options.full_document || false,
+    full : options.full || false,
     per_page : options.per_page || 100
   });
 

--- a/test/documentsSpec.js
+++ b/test/documentsSpec.js
@@ -9,14 +9,14 @@ describe('documents', function() {
   });
 
   it('lists documents', function() {
-    nock('https://api.truevault.com').get('/v1/vaults/my-vault-uuid/documents?page=1&full_document=false&per_page=50')
+    nock('https://api.truevault.com').get('/v1/vaults/my-vault-uuid/documents?page=1&full=false&per_page=50')
       .reply(200, '{}');
 
     truevault.documents.list({
       'vault_id':'my-vault-uuid',
       'per_page':50,
       'page':1,
-      'full_document': false //true to return full documents vs uuids
+      'full': false //true to return full documents vs uuids
     }).then(function(value) {
       should.exist(value);
     }, function(err) {


### PR DESCRIPTION
The full docs were not being included in API response because a parameter was incorrect. (TrueVault API doc is here: https://docs.truevault.com/Documents.html#list-all-documents)
